### PR TITLE
Adjusting git tags in advanced config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 Advanced Configuration
 ======================
 
-Each of the services and honeypots in the CommunityHoneyNetwork project should work together out of the box following the [Quickstart Guide](quickstart.md). More advanced configuration options can be configured using an /etc/sysconfig/<servicename> or /etc/default/<servicename> file for CentOS-based or Ubuntu-based systems, respectively.
+Each of the services and honeypots in the CommunityHoneyNetwork project should work together out of the box following the [Quickstart Guide](quickstart.md). More advanced configuration options can be configured using an /etc/default/<servicename> file for Ubuntu-based systems.
 
 Services running in Docker containers can be configured this way as well, mounting the configuration files into place using the `--volume` argument for Docker.
 
@@ -14,7 +14,6 @@ The following is an example of a shared configuration file, using default values
 CHNSERVER_DEBUG=false
 
 EMAIL=admin@localhost
-SERVER_BASE_URL='http://127.0.0.1'
 HONEYMAP_URL=''
 
 MAIL_SERVER='127.0.0.1'
@@ -59,22 +58,22 @@ version: '2'
 services:
   mongodb:
     build:
-      dockerfile: ./Dockerfile-centos
-      context: https://github.com/CommunityHoneyNetwork/mongodb.git#v1.1
+      dockerfile: ./Dockerfile-ubuntu
+      context: https://github.com/CommunityHoneyNetwork/mongodb.git#v1.5
     image: mongodb:centos
     volumes:
       - ./storage/mongodb:/var/lib/mongo:z
   redis:
     build:
-      dockerfile: ./Dockerfile-centos
-      context: https://github.com/CommunityHoneyNetwork/redis.git#v1.1
+      dockerfile: ./Dockerfile-ubuntu
+      context: https://github.com/CommunityHoneyNetwork/redis.git#v1.5
     image: redis:centos
     volumes:
       - ./storage/redis:/var/lib/redis:z
   hpfeeds:
     build:
-      dockerfile: ./Dockerfile-centos
-      context: https://github.com/CommunityHoneyNetwork/hpfeeds.git#v1.1
+      dockerfile: ./Dockerfile-ubuntu
+      context: https://github.com/CommunityHoneyNetwork/hpfeeds.git#v1.5
     image: hpfeeds:centos
     links:
       - mongodb:mongodb
@@ -82,16 +81,16 @@ services:
       - "10000:10000"
   mnemosyne:
     build:
-      dockerfile: ./Dockerfile-centos
-      context: https://github.com/CommunityHoneyNetwork/mnemosyne.git#v1.1
+      dockerfile: ./Dockerfile-ubuntu
+      context: https://github.com/CommunityHoneyNetwork/mnemosyne.git#v1.5
     image: mnemosyne:centos
     links:
       - mongodb:mongodb
       - hpfeeds:hpfeeds
   chnserver:
     build:
-      dockerfile: ./Dockerfile-centos
-      context: https://github.com/CommunityHoneyNetwork/CHN-Server.git#v1.1
+      dockerfile: ./Dockerfile-ubuntu
+      context: https://github.com/CommunityHoneyNetwork/CHN-Server.git#v1.5
     image: chnserver:centos
     volumes:
       - ./config/collector:/etc/collector:z

--- a/docs/cowrie.md
+++ b/docs/cowrie.md
@@ -79,7 +79,7 @@ services:
   cowrie:
     image: stingar/cowrie:latest
     volumes:
-      - ./cowrie.sysconfig:/etc/sysconfig/cowrie
+      - ./cowrie.sysconfig:/etc/default/cowrie
       - ./cowrie:/etc/cowrie
     ports:
       - "22:2222"

--- a/docs/honeypots.md
+++ b/docs/honeypots.md
@@ -16,6 +16,7 @@ The default deployment model uses Docker and Docker Compose to deploy containers
 ## Deploying More Honeypots
 
 Currently the following Honeypots are supported with CHN:
+
 * [Cowrie](cowrie.md)
 * [Dionaea](dionaea.md)
 * [Glastopf](glastopf.md)
@@ -47,4 +48,4 @@ docker-compose and adding the local user to the docker group
 
 **Please Note** that you should generally not change the ports in the 
 sysconfig files, but rather change the ports that Docker translates 
-connectiojns to (i.e., in the )
+connects to (i.e., in the )

--- a/docs/nondocker.md
+++ b/docs/nondocker.md
@@ -1,6 +1,9 @@
 Deploying without Docker
 ========================
 
+**WARNING** non-container deployments are no longer supported. The follwing 
+information is historical and will be removed soon. 
+
 In addition to running within Docker, you can also deploy each of the CHN Server services and honeypots as regular services on a host (or many hosts).  The container images are all built using [Ansible](https://www.ansible.com/) playbooks.  These playbooks can be run on regular hosts to install the services as normal services, without running as Docker containers.
 
 **Note:** BETA STATUS - The ability to install directly to regular hosts _should_ work, but is still in development and _might_ break something.  Use at your own risk.  You're most likely to be successful installing on a freshly installed system, rather than a shared host.


### PR DESCRIPTION
This updates the example "building from source" docker-compose to use the latest release tag (1.5) and changes all references to the Ubuntu-based Dockerfile. 

Please have mercy on my inability to properly use git, and squash merge this with only the above line left as reference.